### PR TITLE
Restrict images to the width of the preview window

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -56,6 +56,10 @@ body, html {
     color: var(--sn-stylekit-info-color);
   }
 
+  img {
+    max-width: 100%;
+  }
+
   pre {
     background: var(--sn-stylekit-background-color);
     color: var(--sn-stylekit-foreground-color);


### PR DESCRIPTION
Currently very large images overflow when the image is wider than the preview window. Added max-width CSS property for images so that image width is restricted by the preview window's width.