### PR TITLE
Move preview toolbar buttons to the left

### DIFF
--- a/dist/dist.js
+++ b/dist/dist.js
@@ -742,7 +742,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
     shortcuts: {
       toggleSideBySide: "Cmd-Alt-P"
     },
-    toolbar: ["heading", "bold", "italic", "strikethrough", "|", "quote", "code", "|", "unordered-list", "ordered-list", "|", "clean-block", "|", "link", "image", "|", "table", "|", {
+    toolbar: [{
       className: "fa fa-eye",
       default: true,
       name: "preview",
@@ -763,7 +763,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
         window.easymde.toggleSideBySide();
         saveMetadata();
       }
-    }]
+    }, "|", "heading", "bold", "italic", "strikethrough", "|", "quote", "code", "|", "unordered-list", "ordered-list", "|", "clean-block", "|", "link", "image", "|", "table"]
   });
 
   function saveMetadata() {

--- a/src/main.js
+++ b/src/main.js
@@ -64,13 +64,6 @@ document.addEventListener("DOMContentLoaded", function(event) {
       toggleSideBySide: "Cmd-Alt-P"
     },
     toolbar:[
-      "heading", "bold", "italic", "strikethrough",
-      "|", "quote", "code",
-      "|", "unordered-list", "ordered-list",
-      "|", "clean-block",
-      "|", "link", "image",
-      "|", "table",
-      "|",
       {
         className: "fa fa-eye",
         default: true,
@@ -93,7 +86,14 @@ document.addEventListener("DOMContentLoaded", function(event) {
           window.easymde.toggleSideBySide();
           saveMetadata();
         }
-      }
+      },
+      "|",
+      "heading", "bold", "italic", "strikethrough",
+      "|", "quote", "code",
+      "|", "unordered-list", "ordered-list",
+      "|", "clean-block",
+      "|", "link", "image",
+      "|", "table"
     ]
   });
 


### PR DESCRIPTION
Having the preview buttons on the left is a lot easier to use on mobile. With the preview buttons on the right (current behavior) I always need to scroll the toolbar before I can touch the preview button.