### PR TITLE
Aligned heading font sizes

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -148,6 +148,22 @@
   color: var(--sn-stylekit-info-contrast-color) !important;
   background: var(--sn-stylekit-info-color) !important;
 }
+.CodeMirror .cm-header-1 {
+  font-size: 200% !important;
+  line-height: 200% !important;
+}
+.CodeMirror .cm-header-2 {
+  font-size: 150% !important;
+  line-height: 150% !important;
+}
+.CodeMirror .cm-header-3 {
+  font-size: 117% !important;
+  line-height: 117% !important;
+}
+.CodeMirror .cm-header-4 {
+  font-size: 112% !important;
+  line-height: 112% !important;
+}
 .CodeMirror .cm-formatting-header, .CodeMirror .cm-formatting-strong, .CodeMirror .cm-formatting-em {
   opacity: 0.2;
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -163,6 +163,26 @@ body, html {
     }
   }
 
+  .cm-header-1 {
+    font-size: 200% !important;
+    line-height: 200% !important;
+  }
+
+  .cm-header-2 {
+    font-size: 150% !important;
+    line-height: 150% !important;
+  }
+
+  .cm-header-3 {
+    font-size: 117% !important;
+    line-height: 117% !important;
+  }
+
+  .cm-header-4 {
+    font-size: 112% !important;
+    line-height: 112% !important;
+  }
+
   // Faded Markdown syntax
   .cm-formatting-header, .cm-formatting-strong, .cm-formatting-em {
     opacity: 0.2;


### PR DESCRIPTION
Aligned heading font sizes with heading font sizes used by other editors (Minimal Markdown, Simple Markdown Editor). Font sizes were a little bit to large before. With this PR they will also be more in line with the font sizes used in the Preview window.

Before:
<img width="261" alt="Screen Shot 2019-07-21 at 14 35 50" src="https://user-images.githubusercontent.com/355541/61595404-d9f28480-abc4-11e9-8eb1-24e27cae43eb.png">

After:
<img width="300" alt="Screen Shot 2019-07-21 at 14 29 49" src="https://user-images.githubusercontent.com/355541/61595397-c2b39700-abc4-11e9-96c4-420cab122e1f.png">
