### PR TITLE
fix: update css to better handle code block overflow

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -82,6 +82,7 @@
   border: 1px solid var(--sn-stylekit-border-color);
   padding: 20px;
   border-radius: 3px;
+  overflow-x: auto;
 }
 .editor-preview-active table, .editor-preview-active-side table {
   display: block;

--- a/src/main.scss
+++ b/src/main.scss
@@ -85,6 +85,7 @@ body, html {
     border: 1px solid var(--sn-stylekit-border-color);
     padding: 20px;
     border-radius: 3px;
+    overflow-x: auto;
   }
 
   table {


### PR DESCRIPTION
Closes standardnotes/forum#1008 and #40 by adding the suggested CSS snippet from @TheodoreChu . 

I didn't find the .editor-preview class in the CSS on our end, but I changed it in the .editor-preview-active class and it worked for me on Ubuntu Firefox.