### PR TITLE
Use monospace font for editor

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -142,7 +142,7 @@
   color: var(--sn-stylekit-info-contrast-color) !important;
   background: var(--sn-stylekit-info-color) !important;
 }
-.CodeMirror .CodeMirror-code, .CodeMirror .editor-preview {
+.CodeMirror .CodeMirror-code {
   font-family: var(--sn-stylekit-monospace-font) !important;
 }
 .CodeMirror .cm-header {

--- a/dist/dist.css
+++ b/dist/dist.css
@@ -142,6 +142,9 @@
   color: var(--sn-stylekit-info-contrast-color) !important;
   background: var(--sn-stylekit-info-color) !important;
 }
+.CodeMirror .CodeMirror-code {
+  font-family: var(--sn-stylekit-monospace-font) !important;
+}
 .CodeMirror .cm-header {
   color: var(--sn-stylekit-editor-foreground-color);
 }

--- a/dist/dist.css
+++ b/dist/dist.css
@@ -142,7 +142,7 @@
   color: var(--sn-stylekit-info-contrast-color) !important;
   background: var(--sn-stylekit-info-color) !important;
 }
-.CodeMirror .CodeMirror-code {
+.CodeMirror .CodeMirror-code, .CodeMirror .editor-preview {
   font-family: var(--sn-stylekit-monospace-font) !important;
 }
 .CodeMirror .cm-header {

--- a/src/main.scss
+++ b/src/main.scss
@@ -156,6 +156,10 @@ body, html {
     }
   }
 
+  .CodeMirror-code {
+    font-family: var(--sn-stylekit-monospace-font) !important;
+  }
+
   .cm-header {
     color: var(--sn-stylekit-editor-foreground-color);
     &.CodeMirror-selectedtext {

--- a/src/main.scss
+++ b/src/main.scss
@@ -156,7 +156,7 @@ body, html {
     }
   }
 
-  .CodeMirror-code, .editor-preview {
+  .CodeMirror-code {
     font-family: var(--sn-stylekit-monospace-font) !important;
   }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -156,7 +156,7 @@ body, html {
     }
   }
 
-  .CodeMirror-code {
+  .CodeMirror-code, .editor-preview {
     font-family: var(--sn-stylekit-monospace-font) !important;
   }
 


### PR DESCRIPTION
This PR styles the EasyMDE editor to use a monospace font. Only the "editor" mode styles have been changed; the "preview" mode is unchanged. This change was inspired by a [Reddit post](https://www.reddit.com/r/StandardNotes/comments/hyejpg/monospace_markdown/).

This change was tested by installing the extension (from [this release](https://github.com/noizwaves/markdown-pro/releases/tag/monospace-2) on the fork) into the Standard Notes application, and loading some sample Markdown. These are screenshots from the Linux application:
![Linux After](https://user-images.githubusercontent.com/1007983/89115440-76d93600-d445-11ea-8281-0461258a634c.png "Linux After")
![Linux Before](https://user-images.githubusercontent.com/1007983/89115438-72148200-d445-11ea-82af-e4482c7b13e0.png "Linux Before")

This is what it looks like running on an iPhone 6:
![iOS After](https://user-images.githubusercontent.com/1007983/89115469-c61f6680-d445-11ea-8a28-6b7426279c39.PNG "iOS After")

I did try changing the "preview" mode font to be exclusively monospace as well, but it didn't look quite right.
